### PR TITLE
Correct bug in unique

### DIFF
--- a/chapters/arrays/removing-duplicate-elements-from-arrays.md
+++ b/chapters/arrays/removing-duplicate-elements-from-arrays.md
@@ -12,8 +12,8 @@ You want to remove duplicate elements from an array.
 {% highlight coffeescript %}
 Array::unique = ->
   output = {}
-  output[@[key]] = @[key] for key in [0...@length]
-  value for key, value of output
+  output[key] = key for key in @
+  value for own key, value of output
 
 [1,1,2,2,2,3,4,5,6,6,6,"a","a","b","d","b","c"].unique()
 # => [ 1, 2, 3, 4, 5, 6, 'a', 'b', 'd', 'c' ]


### PR DESCRIPTION
This fixes an issue where [].unique() evaluated to [null].


For some godawful reason 
```
console.log(JSON.stringify(value) + " => " + JSON.stringify(value)) for key, value of {}
```
logs
```
undefined => undefined 
```

So we must ensure we only return properties owned by the output object, so that null doesn't get added to our array of unique elements. This issue may be specific to my setup (Latest version of Chrome, running on a Windows VM in close proximity to an Indian burial ground), but I believe this change still improves the clarity and correctness of the example.
